### PR TITLE
Enable default dark theme and persist kanban drag-and-drop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ const AppContent: React.FC = () => {
   };
 
   return (
-    <div className="flex h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="flex h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       <Sidebar currentPage={currentPage} onPageChange={setCurrentPage} />
       <div className="flex-1 overflow-auto">
         {renderPage()}

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -26,36 +26,36 @@ export const Login: React.FC = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-100 to-blue-200 dark:from-gray-900 dark:via-gray-950 dark:to-black flex items-center justify-center p-4 transition-colors">
       <div className="max-w-md w-full space-y-8">
-        <div className="bg-white rounded-2xl shadow-xl p-8">
+        <div className="bg-white/90 dark:bg-gray-900/90 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 backdrop-blur p-8">
           {/* Header */}
           <div className="text-center mb-8">
-            <div className="bg-blue-600 p-3 rounded-full w-16 h-16 mx-auto mb-4">
+            <div className="bg-blue-600/90 dark:bg-blue-500/80 p-3 rounded-full w-16 h-16 mx-auto mb-4">
               <Building2 className="w-10 h-10 text-white" />
             </div>
-            <h2 className="text-3xl font-bold text-gray-900">Dashboard de Vendas</h2>
-            <p className="text-gray-600 mt-2">Fábrica de Móveis Planejados</p>
+            <h2 className="text-3xl font-bold text-gray-900 dark:text-white">Dashboard de Vendas</h2>
+            <p className="text-gray-600 dark:text-gray-300 mt-2">Fábrica de Móveis Planejados</p>
           </div>
 
           {/* Login Form */}
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Email
               </label>
               <input
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors bg-white dark:bg-gray-900 dark:text-white"
                 placeholder="seu@email.com"
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Senha
               </label>
               <div className="relative">
@@ -63,14 +63,14 @@ export const Login: React.FC = () => {
                   type={showPassword ? 'text' : 'password'}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors pr-12"
+                  className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors pr-12 bg-white dark:bg-gray-900 dark:text-white"
                   placeholder="••••••••"
                   required
                 />
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
                 >
                   {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
                 </button>
@@ -78,7 +78,7 @@ export const Login: React.FC = () => {
             </div>
 
             {error && (
-              <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg text-sm">
+              <div className="bg-red-50 dark:bg-red-900/40 border border-red-200 dark:border-red-700 text-red-600 dark:text-red-300 px-4 py-3 rounded-lg text-sm">
                 {error}
               </div>
             )}
@@ -86,7 +86,7 @@ export const Login: React.FC = () => {
             <button
               type="submit"
               disabled={loading}
-              className="w-full bg-blue-600 text-white py-3 px-4 rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-2"
+              className="w-full bg-blue-600 dark:bg-blue-500 text-white py-3 px-4 rounded-lg hover:bg-blue-700 dark:hover:bg-blue-400 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-2"
             >
               {loading ? (
                 <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
@@ -100,14 +100,14 @@ export const Login: React.FC = () => {
           </form>
 
           {/* Demo Accounts */}
-          <div className="mt-8 pt-6 border-t border-gray-200">
-            <p className="text-sm text-gray-600 mb-4 text-center">Contas de demonstração:</p>
+          <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+            <p className="text-sm text-gray-600 dark:text-gray-300 mb-4 text-center">Contas de demonstração:</p>
             <div className="space-y-2">
               {demoAccounts.map((account, index) => (
-                <div key={index} className="bg-gray-50 p-3 rounded-lg">
+                <div key={index} className="bg-gray-50 dark:bg-gray-800/70 p-3 rounded-lg border border-gray-100 dark:border-gray-700">
                   <div className="flex justify-between items-center text-sm">
-                    <span className="font-medium text-gray-700">{account.role}</span>
-                    <div className="text-gray-500">
+                    <span className="font-medium text-gray-700 dark:text-gray-200">{account.role}</span>
+                    <div className="text-gray-500 dark:text-gray-400">
                       <span className="mr-2">{account.email}</span>
                       <span>•</span>
                       <span className="ml-2">{account.password}</span>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -4,16 +4,25 @@ import { ThemeContextType } from '../types';
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null;
+      const initialTheme = savedTheme ?? 'dark';
 
-  useEffect(() => {
-    const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null;
-    if (savedTheme) {
-      setTheme(savedTheme);
+      if (typeof document !== 'undefined') {
+        document.documentElement.classList.toggle('dark', initialTheme === 'dark');
+      }
+
+      return initialTheme;
     }
-  }, []);
+    return 'dark';
+  });
 
   useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
     document.documentElement.classList.toggle('dark', theme === 'dark');
     localStorage.setItem('theme', theme);
   }, [theme]);

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-gray-50 text-gray-900 transition-colors duration-300;
+  }
+
+  .dark body {
+    @apply bg-gray-900 text-gray-100;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,6 +61,7 @@ export interface KanbanCard {
   priority: 'alta' | 'media' | 'baixa';
   responsible: string;
   notes?: string;
+  status: ProductionStatus;
 }
 
 export interface KanbanColumn {


### PR DESCRIPTION
## Summary
- default the application to the dark theme, including updated base styles and login visuals
- persist production kanban column order in local storage, update card status metadata, and highlight drop targets
- persist lead kanban drag-and-drop state in local storage while surfacing the current status in the detail modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcf61754748333bd7787e4f32853b5