### PR TITLE
Enable Kanban drag-and-drop persistence

### DIFF
--- a/src/services/kanban.ts
+++ b/src/services/kanban.ts
@@ -1,0 +1,53 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { KanbanCard, ProductionStatus } from '../types';
+
+type ColumnState = {
+  status: ProductionStatus;
+  cards: KanbanCard[];
+};
+
+export class KanbanService {
+  private client: SupabaseClient | null;
+  private tableName: string;
+
+  constructor() {
+    const url = import.meta.env.VITE_SUPABASE_URL;
+    const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
+    this.tableName = import.meta.env.VITE_SUPABASE_KANBAN_TABLE || 'production_projects';
+
+    if (!url || !key) {
+      console.warn('[KanbanService] Supabase credentials are not configured.');
+      this.client = null;
+      return;
+    }
+
+    this.client = createClient(url, key);
+  }
+
+  async persistColumns(columns: ColumnState[]): Promise<void> {
+    if (!this.client) {
+      throw new Error('Supabase client is not configured.');
+    }
+
+    const updates = columns.flatMap(column =>
+      column.cards.map((card, index) => ({
+        id: card.id,
+        status: card.status,
+        position: index,
+        updated_at: new Date().toISOString()
+      }))
+    );
+
+    if (updates.length === 0) {
+      return;
+    }
+
+    const { error } = await this.client
+      .from(this.tableName)
+      .upsert(updates, { onConflict: 'id' });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- wire the kanban board drag-and-drop flow to a new Supabase-backed service so status changes persist
- surface optimistic UI feedback with loading spinners, success/error indicators, and an error banner when persistence fails
- keep local column state in sync with backend updates while maintaining the selected card information

## Testing
- npm run lint *(fails: repository already contains unused variable lint errors outside the updated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dcfb8f98848333812f44df691b2fc2