### PR TITLE
Add dark mode enhancements and fix Kanban drag interactions

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -64,10 +64,10 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
         <div className="flex items-center space-x-3">
           <RefreshCw className="w-8 h-8 text-blue-600 animate-spin" />
-          <span className="text-xl font-semibold text-gray-700">Carregando dados...</span>
+          <span className="text-xl font-semibold text-gray-700 dark:text-gray-200">Carregando dados...</span>
         </div>
       </div>
     );
@@ -75,20 +75,20 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center max-w-md">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="text-center max-w-md bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-8 shadow-xl">
           <WifiOff className="w-16 h-16 text-red-500 mx-auto mb-4" />
-          <div className="text-red-600 text-xl font-semibold mb-2">Erro de Conexão</div>
-          <div className="text-gray-600 mb-4">{error}</div>
+          <div className="text-red-600 dark:text-red-400 text-xl font-semibold mb-2">Erro de Conexão</div>
+          <div className="text-gray-600 dark:text-gray-300 mb-4">{error}</div>
           <button
             onClick={handleRefresh}
             className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
           >
             Tentar Novamente
           </button>
-          <div className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg text-left">
-            <h4 className="font-semibold text-yellow-800 mb-2">Configuração Necessária:</h4>
-            <ol className="text-sm text-yellow-700 space-y-1">
+          <div className="mt-4 p-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-lg text-left">
+            <h4 className="font-semibold text-yellow-800 dark:text-yellow-300 mb-2">Configuração Necessária:</h4>
+            <ol className="text-sm text-yellow-700 dark:text-yellow-200 space-y-1">
               <li>1. Obtenha uma chave da Google Sheets API</li>
               <li>2. Configure a variável VITE_GOOGLE_API_KEY no arquivo .env</li>
               <li>3. Certifique-se que a planilha está pública para leitura</li>
@@ -100,9 +100,9 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-300">
       {/* Header */}
-      <div className="bg-white shadow-sm border-b">
+      <div className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center space-x-3">
@@ -110,8 +110,8 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
                 <TrendingUp className="w-6 h-6 text-white" />
               </div>
               <div>
-                <h1 className="text-xl font-bold text-gray-900">Dashboard de Vendas</h1>
-                <p className="text-sm text-gray-600">Fábrica de Móveis Planejados</p>
+                <h1 className="text-xl font-bold text-gray-900 dark:text-white">Dashboard de Vendas</h1>
+                <p className="text-sm text-gray-600 dark:text-gray-300">Fábrica de Móveis Planejados</p>
               </div>
             </div>
             <div className="flex items-center space-x-4">
@@ -122,14 +122,14 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
                   className="w-8 h-8 rounded-full"
                 />
                 <div className="text-sm">
-                  <p className="font-medium text-gray-900">{user?.name}</p>
-                  <p className="text-gray-500 capitalize">{user?.role}</p>
+                  <p className="font-medium text-gray-900 dark:text-white">{user?.name}</p>
+                  <p className="text-gray-500 dark:text-gray-400 capitalize">{user?.role}</p>
                 </div>
               </div>
-              <div className="flex items-center space-x-2 text-sm text-gray-500">
+              <div className="flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400">
                 <Wifi className="w-4 h-4 text-green-500" />
                 <span>
-                  {lastUpdate 
+                  {lastUpdate
                     ? `Última atualização: ${lastUpdate.toLocaleString('pt-BR')}`
                     : 'Conectando...'
                   }
@@ -170,13 +170,13 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
 
           {/* Status da Conexão */}
           {data.length > 0 && (
-            <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+            <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded-lg p-4">
               <div className="flex items-center space-x-2">
                 <Wifi className="w-5 h-5 text-green-600" />
-                <span className="text-green-800 font-medium">
+                <span className="text-green-800 dark:text-green-300 font-medium">
                   ✅ Conectado à planilha Google Sheets (Pública)
                 </span>
-                <span className="text-green-600 text-sm">
+                <span className="text-green-600 dark:text-green-200 text-sm">
                   • {data.length} registros carregados
                   {filteredData.length !== data.length && (
                     <span> • {filteredData.length} filtrados</span>
@@ -187,13 +187,14 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
           )}
 
           {/* KPI Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4 items-stretch">
             <KPICard
               title="Vendas Total"
               value={formatCurrency(kpis.totalSales)}
               trend={{ value: 12.5, isPositive: true }}
               icon={<DollarSign className="w-6 h-6" />}
               variant="compact"
+              className="h-full"
             />
             <KPICard
               title="Projetos"
@@ -201,6 +202,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
               trend={{ value: 8.2, isPositive: true }}
               icon={<ShoppingBag className="w-6 h-6" />}
               variant="compact"
+              className="h-full"
             />
             <KPICard
               title="Lucro Total"
@@ -208,6 +210,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
               trend={{ value: 15.3, isPositive: true }}
               icon={<Target className="w-6 h-6" />}
               variant="compact"
+              className="h-full"
             />
             <KPICard
               title="Margem Média"
@@ -215,6 +218,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
               trend={{ value: 2.1, isPositive: true }}
               icon={<TrendingUp className="w-6 h-6" />}
               variant="compact"
+              className="h-full"
             />
             <KPICard
               title="Ticket Médio"
@@ -222,33 +226,38 @@ export const Dashboard: React.FC<DashboardProps> = ({ onPageChange }) => {
               trend={{ value: 5.7, isPositive: true }}
               icon={<Users className="w-6 h-6" />}
               variant="compact"
+              className="h-full"
             />
           </div>
 
           {/* Charts Row 1 */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-stretch">
             <BarChart
               data={vendorData}
               title="Vendas por Vendedor"
               color="bg-blue-500"
+              className="h-full"
             />
             <BarChart
               data={cityData}
               title="Vendas por Cidade"
               color="bg-green-500"
+              className="h-full"
             />
           </div>
 
           {/* Charts Row 2 */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-stretch">
             <PieChart
               data={paymentData}
               title="Formas de Pagamento"
+              className="h-full"
             />
             <PieChart
               data={statusData}
               title="Status dos Projetos"
               colors={['#10B981', '#3B82F6', '#F59E0B', '#EF4444']}
+              className="h-full"
             />
           </div>
 

--- a/src/components/DateFilter.tsx
+++ b/src/components/DateFilter.tsx
@@ -17,41 +17,41 @@ export const DateFilter: React.FC<DateFilterProps> = ({
   onReset
 }) => {
   return (
-    <div className="bg-white rounded-xl shadow-md p-6 border border-gray-100">
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 border border-gray-100 dark:border-gray-700">
       <div className="flex items-center space-x-2 mb-4">
         <Calendar className="w-5 h-5 text-blue-600" />
-        <h3 className="text-lg font-semibold text-gray-900">Filtros de Data</h3>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Filtros de Data</h3>
       </div>
-      
+
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             Data Início
           </label>
           <input
             type="date"
             value={startDate}
             onChange={(e) => onStartDateChange(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
           />
         </div>
-        
+
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             Data Fim
           </label>
           <input
             type="date"
             value={endDate}
             onChange={(e) => onEndDateChange(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
           />
         </div>
-        
+
         <div className="flex items-end">
           <button
             onClick={onReset}
-            className="w-full px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors duration-200"
+            className="w-full px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors duration-200"
           >
             Limpar Filtros
           </button>

--- a/src/components/KPICard.tsx
+++ b/src/components/KPICard.tsx
@@ -23,7 +23,7 @@ export const KPICard: React.FC<KPICardProps> = ({
 }) => {
   if (variant === 'compact') {
     return (
-      <div className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all duration-300 ${className}`}>
+      <div className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 border border-gray-100 dark:border-gray-700 hover:shadow-md transition-all duration-300 flex flex-col h-full ${className}`}>
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-sm font-medium text-gray-600 dark:text-gray-300 uppercase tracking-wide">{title}</h3>
           {icon && (
@@ -32,8 +32,8 @@ export const KPICard: React.FC<KPICardProps> = ({
             </div>
           )}
         </div>
-        
-        <div className="flex items-end justify-between">
+
+        <div className="flex items-end justify-between mt-auto">
           <div className="text-2xl font-bold text-gray-900 dark:text-white leading-none mb-1">
             {value}
           </div>
@@ -55,7 +55,7 @@ export const KPICard: React.FC<KPICardProps> = ({
   }
 
   return (
-    <div className={`bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 border border-gray-100 dark:border-gray-700 hover:shadow-lg transition-shadow duration-300 ${className}`}>
+    <div className={`bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 border border-gray-100 dark:border-gray-700 hover:shadow-lg transition-shadow duration-300 flex flex-col h-full ${className}`}>
       <div className="flex items-start justify-between">
         <div className="flex-1">
           <p className="text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">{title}</p>

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import { DragDropContext, Draggable, DropResult } from 'react-beautiful-dnd';
 import {
   Plus,
   Calendar,
@@ -15,6 +15,7 @@ import { useSheetData } from '../hooks/useSheetData';
 import { KanbanCard, ProductionStatus } from '../types';
 import { formatCurrency } from '../utils/calculations';
 import { KanbanService } from '../services/kanban';
+import { StrictModeDroppable } from './StrictModeDroppable';
 const STORAGE_KEY = 'production-kanban-state';
 
 const createEmptyColumns = (): Record<ProductionStatus, KanbanCard[]> => ({
@@ -340,9 +341,9 @@ export const KanbanBoard: React.FC = () => {
         <DragDropContext onDragEnd={handleDragEnd}>
           <div className="flex space-x-6 min-w-max">
           {kanbanData.map((column) => (
-            <Droppable droppableId={column.id} key={column.id}>
+            <StrictModeDroppable droppableId={column.id} key={column.id}>
               {(provided, snapshot) => (
-                <div 
+                <div
                   ref={provided.innerRef}
                   {...provided.droppableProps}
                   className="w-80 flex-shrink-0"
@@ -434,9 +435,9 @@ export const KanbanBoard: React.FC = () => {
                   </div>
                 )}
               </div>
-                </div>
+              </div>
               )}
-            </Droppable>
+            </StrictModeDroppable>
           ))}
           </div>
         </DragDropContext>

--- a/src/components/LeadsBoard.tsx
+++ b/src/components/LeadsBoard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import { DragDropContext, Draggable, DropResult } from 'react-beautiful-dnd';
 import { 
   Plus, 
   Phone, 
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { Lead, LeadStatus } from '../types';
 import { formatCurrency } from '../utils/calculations';
+import { StrictModeDroppable } from './StrictModeDroppable';
 const LEADS_STORAGE_KEY = 'leads-kanban-state';
 
 const createInitialLeadsState = (): Record<LeadStatus, Lead[]> => ({
@@ -239,9 +240,9 @@ export const LeadsBoard: React.FC = () => {
         <DragDropContext onDragEnd={handleDragEnd}>
           <div className="flex space-x-6 min-w-max">
             {Object.entries(statusConfig).map(([status, config]) => (
-              <Droppable droppableId={status} key={status}>
+              <StrictModeDroppable droppableId={status} key={status}>
                 {(provided, snapshot) => (
-                  <div 
+                  <div
                     ref={provided.innerRef}
                     {...provided.droppableProps}
                     className="w-80 flex-shrink-0"
@@ -319,7 +320,7 @@ export const LeadsBoard: React.FC = () => {
                     </div>
                   </div>
                 )}
-              </Droppable>
+              </StrictModeDroppable>
             ))}
           </div>
         </DragDropContext>
@@ -614,12 +615,9 @@ export const LeadsBoard: React.FC = () => {
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
                 >
                   <option value="">Selecione uma especialidade</option>
-                  <option value="Cozinhas">Cozinhas</option>
-                  <option value="Dormitórios">Dormitórios</option>
-                  <option value="Banheiros">Banheiros</option>
-                  <option value="Escritórios">Escritórios</option>
-                  <option value="Salas">Salas</option>
-                  <option value="Geral">Geral</option>
+                  <option value="B2B">B2B</option>
+                  <option value="B2C">B2C</option>
+                  <option value="Ambos B2B e B2C">Ambos B2B e B2C</option>
                 </select>
               </div>
             </div>

--- a/src/components/StatusTable.tsx
+++ b/src/components/StatusTable.tsx
@@ -10,65 +10,65 @@ export const StatusTable: React.FC<StatusTableProps> = ({ data }) => {
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'Finalizado':
-        return 'bg-green-100 text-green-800';
+        return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
       case 'Em Produção':
-        return 'bg-blue-100 text-blue-800';
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
       case 'Orçamento':
-        return 'bg-yellow-100 text-yellow-800';
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300';
       default:
-        return 'bg-gray-100 text-gray-800';
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
     }
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-md border border-gray-100 overflow-hidden">
-      <div className="px-6 py-4 border-b border-gray-200">
-        <h3 className="text-lg font-semibold text-gray-900">Projetos Recentes</h3>
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md border border-gray-100 dark:border-gray-700 overflow-hidden">
+      <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Projetos Recentes</h3>
       </div>
-      
+
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900/40">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 Projeto
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 Cliente
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 Cidade
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 Valor
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 Margem
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 Status
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 Vendedor
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
             {data.slice(0, 10).map((project) => (
-              <tr key={project["ID Projeto"]} className="hover:bg-gray-50">
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+              <tr key={project["ID Projeto"]} className="hover:bg-gray-50 dark:hover:bg-gray-700/60">
+                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
                   {project["Código Projeto"]}
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                   {project.Cliente}
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                   {project.Cidade}
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-semibold">
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 font-semibold">
                   {formatCurrency(project["Valor Final (R$)"])}
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                   {project["Margem Lucro (%)"].toFixed(1)}%
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap">
@@ -76,7 +76,7 @@ export const StatusTable: React.FC<StatusTableProps> = ({ data }) => {
                     {project.Status}
                   </span>
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                   {project["Vendedor Responsável"]}
                 </td>
               </tr>

--- a/src/components/StrictModeDroppable.tsx
+++ b/src/components/StrictModeDroppable.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react';
+import { Droppable, DroppableProps } from 'react-beautiful-dnd';
+
+type StrictModeDroppableProps = DroppableProps;
+
+export const StrictModeDroppable: React.FC<StrictModeDroppableProps> = ({ children, ...props }) => {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const animation = requestAnimationFrame(() => setEnabled(true));
+
+    return () => {
+      cancelAnimationFrame(animation);
+      setEnabled(false);
+    };
+  }, []);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return <Droppable {...props}>{children}</Droppable>;
+};

--- a/src/components/charts/BarChart.tsx
+++ b/src/components/charts/BarChart.tsx
@@ -6,27 +6,29 @@ interface BarChartProps {
   title: string;
   color?: string;
   showPercentage?: boolean;
+  className?: string;
 }
 
-export const BarChart: React.FC<BarChartProps> = ({ 
-  data, 
-  title, 
+export const BarChart: React.FC<BarChartProps> = ({
+  data,
+  title,
   color = 'bg-blue-500',
-  showPercentage = true 
+  showPercentage = true,
+  className = ''
 }) => {
   const maxValue = Math.max(...data.map(item => item.value));
 
   return (
-    <div className="bg-white rounded-xl shadow-md p-6 border border-gray-100">
-      <h3 className="text-lg font-semibold text-gray-900 mb-6">{title}</h3>
-      
+    <div className={`bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 border border-gray-100 dark:border-gray-700 ${className}`}>
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-6">{title}</h3>
+
       <div className="space-y-4">
         {data.map((item, index) => (
           <div key={index} className="space-y-2">
             <div className="flex justify-between items-center text-sm">
-              <span className="font-medium text-gray-700">{item.name}</span>
+              <span className="font-medium text-gray-700 dark:text-gray-200">{item.name}</span>
               <div className="flex items-center space-x-2">
-                <span className="text-gray-900 font-semibold">
+                <span className="text-gray-900 dark:text-white font-semibold">
                   {new Intl.NumberFormat('pt-BR', {
                     style: 'currency',
                     currency: 'BRL',
@@ -35,13 +37,13 @@ export const BarChart: React.FC<BarChartProps> = ({
                   }).format(item.value)}
                 </span>
                 {showPercentage && item.percentage && (
-                  <span className="text-gray-500">
+                  <span className="text-gray-500 dark:text-gray-400">
                     ({item.percentage.toFixed(1)}%)
                   </span>
                 )}
               </div>
             </div>
-            <div className="w-full bg-gray-200 rounded-full h-3">
+            <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3">
               <div
                 className={`h-3 rounded-full ${color} transition-all duration-1000 ease-out`}
                 style={{

--- a/src/components/charts/PieChart.tsx
+++ b/src/components/charts/PieChart.tsx
@@ -5,19 +5,21 @@ interface PieChartProps {
   data: ChartData[];
   title: string;
   colors?: string[];
+  className?: string;
 }
 
-export const PieChart: React.FC<PieChartProps> = ({ 
-  data, 
-  title, 
-  colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#F97316']
+export const PieChart: React.FC<PieChartProps> = ({
+  data,
+  title,
+  colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#F97316'],
+  className = ''
 }) => {
   const total = data.reduce((sum, item) => sum + item.value, 0);
 
   return (
-    <div className="bg-white rounded-xl shadow-md p-6 border border-gray-100">
-      <h3 className="text-lg font-semibold text-gray-900 mb-6">{title}</h3>
-      
+    <div className={`bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 border border-gray-100 dark:border-gray-700 ${className}`}>
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-6">{title}</h3>
+
       <div className="flex flex-col lg:flex-row items-center space-y-6 lg:space-y-0 lg:space-x-6">
         {/* Pie Chart Visual */}
         <div className="relative">
@@ -47,8 +49,8 @@ export const PieChart: React.FC<PieChartProps> = ({
           </svg>
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="text-center">
-              <div className="text-2xl font-bold text-gray-900">{data.length}</div>
-              <div className="text-sm text-gray-500">Total</div>
+              <div className="text-2xl font-bold text-gray-900 dark:text-white">{data.length}</div>
+              <div className="text-sm text-gray-500 dark:text-gray-400">Total</div>
             </div>
           </div>
         </div>
@@ -63,8 +65,8 @@ export const PieChart: React.FC<PieChartProps> = ({
               />
               <div className="flex-1">
                 <div className="flex justify-between items-center">
-                  <span className="text-sm font-medium text-gray-700">{item.name}</span>
-                  <span className="text-sm text-gray-500">
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-200">{item.name}</span>
+                  <span className="text-sm text-gray-500 dark:text-gray-400">
                     {((item.value / total) * 100).toFixed(1)}%
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- polish the dashboard experience with consistent dark theme styling, improved loading/error states, and aligned KPI and chart cards
- add a strict-mode safe droppable wrapper so production and lead Kanbans can drag items across columns again
- update the new vendor modal to offer B2B, B2C, and combined specialty options

## Testing
- npm run build
- npm run lint *(fails due to pre-existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dcff209b188333a0815cee8351413e